### PR TITLE
「Haskell/GHCの書き換え規則（rewrite rules）覚え書き」修正

### DIFF
--- a/articles/haskell-rewrite-rules.md
+++ b/articles/haskell-rewrite-rules.md
@@ -273,7 +273,7 @@ instance MyFunctor IO where
   myFmapIO f (myFmapIO g x) = myFmapIO (f . g) x
 #-}
 
-main = myFmapIO (+ 2) (myFmapIO (* 3) (pure 5)) >>= print
+main = myFmap (+ 2) (myFmap (* 3) (pure 5)) >>= print
 ```
 
 ## newtypeとcoerce


### PR DESCRIPTION
<!-- プルリクエストを作る際は以下にチェックを入れてください： -->

- [x] `README.md` の注意事項を読みました。
- [x] 万が一この変更に著作権が認められた場合でも修正後の文を @minoki が自由に使用することを認めます。

『型クラスのメソッド』の例で、 `myFmap` のコール時に `myFmapIO` の書き換え規則が発火する例となるように、 `main` を修正する PR です。今回の記事もめちゃめちゃ勉強になります……！
